### PR TITLE
Assignment and also pre-{dec,inc}rement are not both needed

### DIFF
--- a/src/FloppyDrive.cpp
+++ b/src/FloppyDrive.cpp
@@ -46,7 +46,7 @@ class FloppyDrive drive[N_DRIVE]; //will be used as extern
 ISR(INT0_vect) //int0 pin 2 of port D
 {
   if (IS_STEP() ) //debounce
-    iTrack = (STEPDIR()) ? --iTrack : ++iTrack;
+    (STEPDIR()) ? --iTrack : ++iTrack;
   SET_TRACKCHANGED();  
 }
 


### PR DESCRIPTION
It's an undefined behavior even though it probably works... but really it's assigning the same value to it.